### PR TITLE
test(cli): expand offline e2e coverage for service integrity and lifecycle

### DIFF
--- a/cmd/kimbap/e2e_test.go
+++ b/cmd/kimbap/e2e_test.go
@@ -538,6 +538,15 @@ func TestE2EStatusShowsLinkHintForDisconnectedService(t *testing.T) {
 	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
 	mustRunOK(t, env, "--no-splash", "service", "install", "github")
 
+	jsonOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "status")
+	payload := decodeJSONMap(t, jsonOut)
+	if got, _ := payload["services"].(float64); got != 1 {
+		t.Fatalf("expected services=1 in status JSON, got %+v", payload)
+	}
+	if got, _ := payload["credentials"].(float64); got != 0 {
+		t.Fatalf("expected credentials=0 in status JSON, got %+v", payload)
+	}
+
 	stdout, stderr, err := e2eRun(t, env, "--no-splash", "status")
 	if err != nil {
 		t.Fatalf("status command failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
@@ -545,14 +554,8 @@ func TestE2EStatusShowsLinkHintForDisconnectedService(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("expected empty stderr from status command, got %q", stderr)
 	}
-	if !strings.Contains(stdout, "Services:") || !strings.Contains(stdout, "1 enabled") {
-		t.Fatalf("expected status output to mention enabled service count, got:\n%s", stdout)
-	}
-	if !strings.Contains(stdout, "Credentials:") || !strings.Contains(stdout, "0 stored") {
-		t.Fatalf("expected status output to mention zero stored credentials, got:\n%s", stdout)
-	}
-	if !strings.Contains(stdout, "Run 'kimbap link github' to connect.") {
-		t.Fatalf("expected status footer to show actionable link hint, got:\n%s", stdout)
+	if !strings.Contains(stdout, "kimbap link github") {
+		t.Fatalf("expected status footer to suggest 'kimbap link github', got:\n%s", stdout)
 	}
 }
 

--- a/cmd/kimbap/e2e_test.go
+++ b/cmd/kimbap/e2e_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -74,6 +76,18 @@ func e2eEnv(t *testing.T) []string {
 	}
 }
 
+func e2eEnvValue(t *testing.T, env []string, key string) string {
+	t.Helper()
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	t.Fatalf("environment key %q not found in %v", key, env)
+	return ""
+}
+
 func testdataAppleNotesPath(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()
@@ -87,6 +101,57 @@ func testdataAppleNotesPath(t *testing.T) string {
 	return path
 }
 
+func writeE2EHTTPManifest(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".yaml")
+	raw := "name: " + name + "\n" +
+		"version: 1.0.0\n" +
+		"description: local e2e http service\n" +
+		"base_url: https://api.example.com\n" +
+		"auth:\n" +
+		"  type: none\n" +
+		"actions:\n" +
+		"  ping:\n" +
+		"    method: GET\n" +
+		"    path: /ping\n" +
+		"    description: ping endpoint\n" +
+		"    risk:\n" +
+		"      level: low\n"
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write http manifest: %v", err)
+	}
+	return path
+}
+
+func writeE2ECommandManifest(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".yaml")
+	raw := "name: " + name + "\n" +
+		"version: 1.0.0\n" +
+		"description: local e2e command service\n" +
+		"adapter: command\n" +
+		"command_spec:\n" +
+		"  executable: /bin/echo\n" +
+		"  json_flag: none\n" +
+		"auth:\n" +
+		"  type: none\n" +
+		"actions:\n" +
+		"  run:\n" +
+		"    command: \"hello-from-command-service\"\n" +
+		"    description: echo a stable fixture value\n" +
+		"    idempotent: true\n" +
+		"    response:\n" +
+		"      type: object\n" +
+		"      text_filter:\n" +
+		"        strip_ansi: true\n" +
+		"    risk:\n" +
+		"      level: low\n"
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write command manifest: %v", err)
+	}
+	return path
+}
+
 func mustRunOK(t *testing.T, env []string, args ...string) (string, string) {
 	t.Helper()
 	stdout, stderr, err := e2eRun(t, env, args...)
@@ -94,6 +159,24 @@ func mustRunOK(t *testing.T, env []string, args ...string) (string, string) {
 		t.Fatalf("command failed: %v\nargs: %v\nstdout:\n%s\nstderr:\n%s", err, args, stdout, stderr)
 	}
 	return stdout, stderr
+}
+
+func decodeJSONMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, raw)
+	}
+	return payload
+}
+
+func decodeJSONArray(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var payload []map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("output is not valid JSON array: %v\noutput:\n%s", err, raw)
+	}
+	return payload
 }
 
 func TestE2EGoldenPath(t *testing.T) {
@@ -253,6 +336,223 @@ func TestE2EHiddenCommandsAccessible(t *testing.T) {
 	stdout, stderr, err := e2eRun(t, env, "--no-splash", "generate", "--help")
 	if err != nil {
 		t.Fatalf("expected hidden generate command to be accessible, got err=%v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+}
+
+func TestE2EServiceValidateSignVerifyFlow(t *testing.T) {
+	env := e2eEnv(t)
+	serviceName := "local-e2e-verify"
+	manifestPath := writeE2EHTTPManifest(t, t.TempDir(), serviceName)
+
+	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
+
+	validateOut, _ := mustRunOK(t, env, "--no-splash", "service", "validate", manifestPath)
+	if !strings.Contains(validateOut, serviceName+" (1.0.0) is valid") {
+		t.Fatalf("expected validate output to mention manifest validity, got:\n%s", validateOut)
+	}
+
+	mustRunOK(t, env, "--no-splash", "service", "install", manifestPath)
+
+	verifyOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "service", "verify", serviceName)
+	verifyPayload := decodeJSONMap(t, verifyOut)
+	if got, _ := verifyPayload["name"].(string); got != serviceName {
+		t.Fatalf("expected verify name %q, got %q", serviceName, got)
+	}
+	if got, _ := verifyPayload["verified"].(bool); !got {
+		t.Fatalf("expected unsigned service to verify successfully, got %+v", verifyPayload)
+	}
+	if got, _ := verifyPayload["locked"].(bool); !got {
+		t.Fatalf("expected installed service to be lockfile-backed, got %+v", verifyPayload)
+	}
+	if got, _ := verifyPayload["signed"].(bool); got {
+		t.Fatalf("expected unsigned service before service sign, got %+v", verifyPayload)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	keyDir := t.TempDir()
+	seedPath := filepath.Join(keyDir, "service-sign.key")
+	if err := os.WriteFile(seedPath, []byte(hex.EncodeToString(priv.Seed())), 0o600); err != nil {
+		t.Fatalf("write signing seed: %v", err)
+	}
+	pubPath := filepath.Join(keyDir, "service-sign.pub")
+	if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(pub)), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	signOut, _ := mustRunOK(t, env, "--no-splash", "service", "sign", "--key", seedPath)
+	if !strings.Contains(signOut, "lockfile signed") {
+		t.Fatalf("expected sign output to confirm lockfile signing, got:\n%s", signOut)
+	}
+
+	signedVerifyOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "service", "verify", serviceName, "--key", pubPath)
+	signedVerifyPayload := decodeJSONMap(t, signedVerifyOut)
+	if got, _ := signedVerifyPayload["verified"].(bool); !got {
+		t.Fatalf("expected signed service to remain verified, got %+v", signedVerifyPayload)
+	}
+	if got, _ := signedVerifyPayload["signed"].(bool); !got {
+		t.Fatalf("expected signed=true after service sign, got %+v", signedVerifyPayload)
+	}
+	if got, _ := signedVerifyPayload["signature_valid"].(bool); !got {
+		t.Fatalf("expected signature_valid=true with pinned key, got %+v", signedVerifyPayload)
+	}
+}
+
+func TestE2EServiceVerifyDetectsTampering(t *testing.T) {
+	env := e2eEnv(t)
+	serviceName := "local-e2e-tamper"
+	manifestPath := writeE2EHTTPManifest(t, t.TempDir(), serviceName)
+
+	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
+	mustRunOK(t, env, "--no-splash", "service", "install", manifestPath)
+
+	servicesDir := filepath.Join(e2eEnvValue(t, env, "KIMBAP_DATA_DIR"), "services")
+	installedPath := filepath.Join(servicesDir, serviceName+".yaml")
+	installedData, err := os.ReadFile(installedPath)
+	if err != nil {
+		t.Fatalf("read installed manifest: %v", err)
+	}
+	if err := os.WriteFile(installedPath, append(installedData, []byte("\n# tampered\n")...), 0o644); err != nil {
+		t.Fatalf("tamper installed manifest: %v", err)
+	}
+
+	stdout, stderr, err := e2eRun(t, env, "--no-splash", "--format", "json", "service", "verify", serviceName)
+	if err == nil {
+		t.Fatalf("expected tampered service verify to fail\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "integrity check failed") {
+		t.Fatalf("expected integrity failure in stderr\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	payload := decodeJSONMap(t, stdout)
+	if got, _ := payload["verified"].(bool); got {
+		t.Fatalf("expected verified=false for tampered manifest, got %+v", payload)
+	}
+	if got, _ := payload["locked"].(bool); !got {
+		t.Fatalf("expected locked=true for tampered manifest, got %+v", payload)
+	}
+}
+
+func TestE2ECommandServiceCall(t *testing.T) {
+	env := e2eEnv(t)
+	serviceName := "local-command-e2e"
+	manifestPath := writeE2ECommandManifest(t, t.TempDir(), serviceName)
+
+	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
+	mustRunOK(t, env, "--no-splash", "service", "install", manifestPath)
+
+	stdout, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "call", serviceName+".run")
+	payload := decodeJSONMap(t, stdout)
+
+	if got, _ := payload["Status"].(string); got != "success" {
+		t.Fatalf("expected call status success, got %+v", payload)
+	}
+	output, ok := payload["Output"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected call output object, got %+v", payload)
+	}
+	raw, _ := output["raw"].(string)
+	if !strings.Contains(raw, "hello-from-command-service") {
+		t.Fatalf("expected command output in raw payload, got %+v", output)
+	}
+	meta, ok := payload["Meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected call meta object, got %+v", payload)
+	}
+	if got, _ := meta["adapter_type"].(string); got != "command" {
+		t.Fatalf("expected adapter_type=command, got %+v", meta)
+	}
+}
+
+func TestE2EServiceEnableDisableLifecycle(t *testing.T) {
+	env := e2eEnv(t)
+	serviceName := "local-command-lifecycle"
+	manifestPath := writeE2ECommandManifest(t, t.TempDir(), serviceName)
+
+	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
+	mustRunOK(t, env, "--no-splash", "service", "install", manifestPath, "--no-activate")
+
+	listOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "service", "list")
+	rows := decodeJSONArray(t, listOut)
+	foundDisabled := false
+	for _, row := range rows {
+		if got, _ := row["name"].(string); got != serviceName {
+			continue
+		}
+		if enabled, _ := row["enabled"].(bool); enabled {
+			t.Fatalf("expected service %q to be disabled after --no-activate install, got %+v", serviceName, row)
+		}
+		if status, _ := row["status"].(string); status != "disabled" {
+			t.Fatalf("expected service %q status=disabled, got %+v", serviceName, row)
+		}
+		foundDisabled = true
+	}
+	if !foundDisabled {
+		t.Fatalf("expected service %q in service list output, got %+v", serviceName, rows)
+	}
+
+	statusOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "status")
+	statusPayload := decodeJSONMap(t, statusOut)
+	if services, _ := statusPayload["services"].(float64); services != 0 {
+		t.Fatalf("expected disabled-only install to keep services count at 0, got %+v", statusPayload)
+	}
+
+	stdout, stderr, err := e2eRun(t, env, "--no-splash", "call", serviceName+".run")
+	if err == nil {
+		t.Fatalf("expected disabled service call to fail\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	combined := stdout + "\n" + stderr
+	if !strings.Contains(combined, "no enabled services found") {
+		t.Fatalf("expected disabled service failure hint, got\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	mustRunOK(t, env, "--no-splash", "service", "enable", serviceName)
+
+	statusOut, _ = mustRunOK(t, env, "--no-splash", "--format", "json", "status")
+	statusPayload = decodeJSONMap(t, statusOut)
+	if services, _ := statusPayload["services"].(float64); services != 1 {
+		t.Fatalf("expected enabled service count to be 1, got %+v", statusPayload)
+	}
+
+	callOut, _ := mustRunOK(t, env, "--no-splash", "--format", "json", "call", serviceName+".run")
+	callPayload := decodeJSONMap(t, callOut)
+	if got, _ := callPayload["Status"].(string); got != "success" {
+		t.Fatalf("expected enabled service call to succeed, got %+v", callPayload)
+	}
+
+	mustRunOK(t, env, "--no-splash", "service", "disable", serviceName)
+
+	statusOut, _ = mustRunOK(t, env, "--no-splash", "--format", "json", "status")
+	statusPayload = decodeJSONMap(t, statusOut)
+	if services, _ := statusPayload["services"].(float64); services != 0 {
+		t.Fatalf("expected disabled service count to return to 0, got %+v", statusPayload)
+	}
+}
+
+func TestE2EStatusShowsLinkHintForDisconnectedService(t *testing.T) {
+	env := e2eEnv(t)
+
+	mustRunOK(t, env, "--no-splash", "init", "--mode", "dev", "--no-services")
+	mustRunOK(t, env, "--no-splash", "service", "install", "github")
+
+	stdout, stderr, err := e2eRun(t, env, "--no-splash", "status")
+	if err != nil {
+		t.Fatalf("status command failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr from status command, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "Services:") || !strings.Contains(stdout, "1 enabled") {
+		t.Fatalf("expected status output to mention enabled service count, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Credentials:") || !strings.Contains(stdout, "0 stored") {
+		t.Fatalf("expected status output to mention zero stored credentials, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Run 'kimbap link github' to connect.") {
+		t.Fatalf("expected status footer to show actionable link hint, got:\n%s", stdout)
 	}
 }
 

--- a/cmd/kimbap/service_lifecycle_test.go
+++ b/cmd/kimbap/service_lifecycle_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -1655,6 +1657,141 @@ func TestServiceCLIInstalledFileParsesAsValidManifest(t *testing.T) {
 		}
 		if manifest.Name != serviceName {
 			t.Fatalf("installed manifest name = %q, want %q", manifest.Name, serviceName)
+		}
+	})
+}
+
+func TestServiceValidateCommandPrintsInstallHintInTextMode(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "local-validate.yaml")
+	writeLocalManifest(t, manifestPath, "local-validate", "1.0.0")
+
+	prev := opts
+	opts = cliOptions{format: "text", noSplash: true}
+	t.Cleanup(func() { opts = prev })
+
+	validateCmd := newServiceValidateCommand()
+	validateCmd.SetArgs([]string{manifestPath})
+	stdout, err := captureStdout(t, validateCmd.Execute)
+	if err != nil {
+		t.Fatalf("service validate failed: %v", err)
+	}
+	if !strings.Contains(stdout, "local-validate (1.0.0) is valid") {
+		t.Fatalf("expected validation success message, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "Install: run 'kimbap service install "+manifestPath+"'.") {
+		t.Fatalf("expected install hint, got %q", stdout)
+	}
+}
+
+func TestServiceSignAndVerifyCommandsWithPinnedKey(t *testing.T) {
+	dataDir := t.TempDir()
+	servicesDir := filepath.Join(dataDir, "services")
+	configPath := writeServiceCLIConfig(t, dataDir, servicesDir)
+
+	manifestPath := filepath.Join(t.TempDir(), "local-signed.yaml")
+	const serviceName = "local-signed"
+	writeLocalManifest(t, manifestPath, serviceName, "1.0.0")
+
+	prev := opts
+	opts = cliOptions{configPath: configPath, format: "text", noSplash: true}
+	t.Cleanup(func() { opts = prev })
+
+	installCmd := newServiceInstallCommand()
+	installCmd.SetArgs([]string{manifestPath})
+	if _, err := captureStdout(t, installCmd.Execute); err != nil {
+		t.Fatalf("service install failed: %v", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 keypair: %v", err)
+	}
+
+	signingKeyPath := filepath.Join(t.TempDir(), "signing.key")
+	if err := os.WriteFile(signingKeyPath, []byte(hex.EncodeToString(priv.Seed())), 0o600); err != nil {
+		t.Fatalf("write signing key: %v", err)
+	}
+	pinnedKeyPath := filepath.Join(t.TempDir(), "signing.pub")
+	if err := os.WriteFile(pinnedKeyPath, []byte(hex.EncodeToString(pub)), 0o644); err != nil {
+		t.Fatalf("write pinned public key: %v", err)
+	}
+
+	signCmd := newServiceSignCommand()
+	signCmd.SetArgs([]string{"--key", signingKeyPath})
+	signOut, err := captureStdout(t, signCmd.Execute)
+	if err != nil {
+		t.Fatalf("service sign failed: %v", err)
+	}
+	if !strings.Contains(signOut, "lockfile signed") {
+		t.Fatalf("expected sign success output, got %q", signOut)
+	}
+	if !strings.Contains(signOut, "Run 'kimbap service verify' to confirm integrity.") {
+		t.Fatalf("expected verify hint after signing, got %q", signOut)
+	}
+
+	verifyCmd := newServiceVerifyCommand()
+	verifyCmd.SetArgs([]string{serviceName, "--key", pinnedKeyPath, "--signatures"})
+	verifyOut, err := captureStdout(t, verifyCmd.Execute)
+	if err != nil {
+		t.Fatalf("service verify with pinned key failed: %v", err)
+	}
+	if !strings.Contains(verifyOut, serviceName+": VERIFIED (locked) [signature: valid]") {
+		t.Fatalf("expected verified signature output, got %q", verifyOut)
+	}
+	if !strings.Contains(verifyOut, "Run 'kimbap service update "+serviceName+"' to update to the latest version.") {
+		t.Fatalf("expected update hint after verify, got %q", verifyOut)
+	}
+}
+
+func TestServiceVerifyCommandReturnsJSONFailureForTamperedManifest(t *testing.T) {
+	dataDir := t.TempDir()
+	servicesDir := filepath.Join(dataDir, "services")
+	configPath := writeServiceCLIConfig(t, dataDir, servicesDir)
+
+	withServiceCLIOpts(t, configPath, func() {
+		manifestPath := filepath.Join(t.TempDir(), "local-verify-tampered.yaml")
+		const serviceName = "local-verify-tampered"
+		writeLocalManifest(t, manifestPath, serviceName, "1.0.0")
+
+		installCmd := newServiceInstallCommand()
+		installCmd.SetArgs([]string{manifestPath})
+		if _, err := captureStdout(t, installCmd.Execute); err != nil {
+			t.Fatalf("service install failed: %v", err)
+		}
+
+		installedPath := filepath.Join(servicesDir, serviceName+".yaml")
+		installedData, err := os.ReadFile(installedPath)
+		if err != nil {
+			t.Fatalf("read installed manifest: %v", err)
+		}
+		if err := os.WriteFile(installedPath, append(installedData, []byte("\n# tampered\n")...), 0o644); err != nil {
+			t.Fatalf("tamper installed manifest: %v", err)
+		}
+
+		verifyCmd := newServiceVerifyCommand()
+		verifyCmd.SetArgs([]string{serviceName})
+		stdout, err := captureStdout(t, verifyCmd.Execute)
+		if err == nil {
+			t.Fatal("expected service verify to fail for tampered manifest")
+		}
+		if !strings.Contains(err.Error(), `service "local-verify-tampered" integrity check failed`) {
+			t.Fatalf("unexpected verify error: %v", err)
+		}
+
+		payload := decodeJSONObject(t, stdout)
+		if got, ok := payload["name"].(string); !ok || got != serviceName {
+			t.Fatalf("expected name %q in payload, got %#v", serviceName, payload["name"])
+		}
+		if got, ok := payload["verified"].(bool); !ok || got {
+			t.Fatalf("expected verified=false in payload, got %#v", payload["verified"])
+		}
+		if got, ok := payload["locked"].(bool); !ok || !got {
+			t.Fatalf("expected locked=true in payload, got %#v", payload["locked"])
+		}
+		expectedDigest, _ := payload["expected_digest"].(string)
+		actualDigest, _ := payload["actual_digest"].(string)
+		if expectedDigest == "" || actualDigest == "" || expectedDigest == actualDigest {
+			t.Fatalf("expected differing digests in payload, got expected=%q actual=%q", expectedDigest, actualDigest)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- expand the default CLI e2e suite with offline coverage for `service validate/sign/verify`
- add tamper-detection coverage for lockfile-backed services
- add command-service lifecycle coverage, including disabled/enabled transitions and `status` guidance
- add command-level regression tests for the same service integrity flows

## Why
The existing `cmd/kimbap/e2e_test.go` suite covered a few golden-path CLI flows, but it did not exercise the newer v0.2.x service integrity surface or stateful service lifecycle transitions.

This PR keeps the default e2e suite focused on deterministic, offline CLI behavior and closes the most obvious coverage gaps without introducing GUI/TCC-dependent instability.

## Scope
Included:
- default CLI e2e coverage in `cmd/kimbap/e2e_test.go`
- command-layer regression coverage in `cmd/kimbap/service_lifecycle_test.go`

Out of scope:
- `darwin && integration` AppleScript GUI tests
- CI workflow changes for opt-in macOS integration runs

I intentionally left the GUI AppleScript integration suite out of this PR. That path has different ergonomics and reliability constraints (TCC prompts, app launch timing, local app state) and should be proposed separately as an opt-in integration-testing change.

## Validation
- `go test ./cmd/kimbap -run '^TestE2E' -count=1` (2 fresh rounds after the final e2e additions)
- `go test ./cmd/kimbap -count=1`
- `go test ./...`

## Notes
I first attempted to push via the local work SSH key (`~/.ssh/id_ed25520`, the `kompas.ai` key), but both `github.com:22` and `ssh.github.com:443` were closed by the remote/network path on this machine. The branch and PR were therefore created with the active GitHub CLI account `Ethan-Dunia`, which is the company account.
