### PR TITLE
feat(cli): add audit summary command

### DIFF
--- a/cmd/kimbap/audit.go
+++ b/cmd/kimbap/audit.go
@@ -21,6 +21,7 @@ func newAuditCommand() *cobra.Command {
 
 	cmd.AddCommand(newAuditTailCommand())
 	cmd.AddCommand(newAuditExportCommand())
+	cmd.AddCommand(newAuditSummaryCommand())
 
 	return cmd
 }
@@ -29,13 +30,15 @@ func newAuditTailCommand() *cobra.Command {
 	var (
 		agent   string
 		service string
+		action  string
+		status  string
 		limit   int
 	)
 	cmd := &cobra.Command{
-		Use:   "tail [--agent <name>] [--service <name>] [--limit 20]",
+		Use:   "tail [--agent <name>] [--service <name>] [--action <name>] [--status <status>] [--limit 20]",
 		Short: "Tail recent audit events",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cfg, err := loadAppConfig()
+			cfg, err := loadAppConfigReadOnly()
 			if err != nil {
 				return err
 			}
@@ -43,9 +46,10 @@ func newAuditTailCommand() *cobra.Command {
 				return fmt.Errorf("--limit must be greater than 0")
 			}
 
+			filter := newAuditEventFilter(agent, service, action, status)
 			selected := make([]audit.AuditEvent, 0, limit)
 			if err := forEachAuditEvent(cfg.Audit.Path, func(e audit.AuditEvent) error {
-				if !auditEventMatches(e, agent, service) {
+				if !filter.matches(e) {
 					return nil
 				}
 				if len(selected) < limit {
@@ -61,10 +65,16 @@ func newAuditTailCommand() *cobra.Command {
 
 			if outputAsJSON() {
 				return printOutput(map[string]any{
-					"path":    cfg.Audit.Path,
-					"count":   len(selected),
-					"filters": map[string]any{"agent": strings.TrimSpace(agent), "service": strings.TrimSpace(service), "limit": limit},
-					"events":  selected,
+					"path":  cfg.Audit.Path,
+					"count": len(selected),
+					"filters": map[string]any{
+						"agent":   filter.Agent,
+						"service": filter.Service,
+						"action":  filter.Action,
+						"status":  filter.Status,
+						"limit":   limit,
+					},
+					"events": selected,
 				})
 			}
 			if len(selected) == 0 {
@@ -101,6 +111,8 @@ func newAuditTailCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&agent, "agent", "", "filter by agent name")
 	cmd.Flags().StringVar(&service, "service", "", "filter by service name")
+	cmd.Flags().StringVar(&action, "action", "", "filter by action name")
+	cmd.Flags().StringVar(&status, "status", "", "filter by audit status")
 	cmd.Flags().IntVar(&limit, "limit", 20, "max events to return")
 	return cmd
 }
@@ -136,10 +148,11 @@ func newAuditExportCommand() *cobra.Command {
 				return fmt.Errorf("--to must be after or equal to --from")
 			}
 
-			cfg, err := loadAppConfig()
+			cfg, err := loadAppConfigReadOnly()
 			if err != nil {
 				return err
 			}
+			filter := newAuditEventFilter(agent, service, "", "")
 			switch strings.ToLower(strings.TrimSpace(format)) {
 			case "", "jsonl", "json":
 				enc := json.NewEncoder(os.Stdout)
@@ -147,7 +160,7 @@ func newAuditExportCommand() *cobra.Command {
 					if e.Timestamp.Before(fromTime) || e.Timestamp.After(toTime) {
 						return nil
 					}
-					if !auditEventMatches(e, agent, service) {
+					if !filter.matches(e) {
 						return nil
 					}
 					return enc.Encode(e)
@@ -165,7 +178,7 @@ func newAuditExportCommand() *cobra.Command {
 					if e.Timestamp.Before(fromTime) || e.Timestamp.After(toTime) {
 						return nil
 					}
-					if !auditEventMatches(e, agent, service) {
+					if !filter.matches(e) {
 						return nil
 					}
 					errorCode := ""
@@ -210,6 +223,53 @@ func newAuditExportCommand() *cobra.Command {
 	return cmd
 }
 
+func newAuditSummaryCommand() *cobra.Command {
+	var (
+		since   string
+		from    string
+		to      string
+		agent   string
+		service string
+		action  string
+		status  string
+	)
+	cmd := &cobra.Command{
+		Use:   "summary [--since <duration> | --from <time> --to <time>] [--agent <name>] [--service <name>] [--action <name>] [--status <status>]",
+		Short: "Show an aggregated audit summary",
+		Example: strings.Join([]string{
+			"  kimbap audit summary --since 24h",
+			"  kimbap audit summary --since 7d --service github",
+			"  kimbap audit summary --from 2026-04-01 --to 2026-04-20 --status error",
+		}, "\n"),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cfg, err := loadAppConfigReadOnly()
+			if err != nil {
+				return err
+			}
+			window, err := resolveAuditQueryWindow(since, from, to, 24*time.Hour, time.Now().UTC())
+			if err != nil {
+				return err
+			}
+			summary, err := summarizeAuditEvents(cfg.Audit.Path, window, newAuditEventFilter(agent, service, action, status))
+			if err != nil {
+				return err
+			}
+			if outputAsJSON() {
+				return printOutput(summary)
+			}
+			return printOutput(renderAuditSummaryText(summary))
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "", "relative time window (for example 24h, 7d)")
+	cmd.Flags().StringVar(&from, "from", "", "from datetime (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&to, "to", "", "to datetime (RFC3339 or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&agent, "agent", "", "filter by agent name")
+	cmd.Flags().StringVar(&service, "service", "", "filter by service name")
+	cmd.Flags().StringVar(&action, "action", "", "filter by action name")
+	cmd.Flags().StringVar(&status, "status", "", "filter by audit status")
+	return cmd
+}
+
 func forEachAuditEvent(path string, handle func(audit.AuditEvent) error) error {
 	if strings.TrimSpace(path) == "" {
 		return fmt.Errorf("audit path is required")
@@ -241,16 +301,6 @@ func forEachAuditEvent(path string, handle func(audit.AuditEvent) error) error {
 		}
 	}
 	return nil
-}
-
-func auditEventMatches(event audit.AuditEvent, agent string, service string) bool {
-	if a := strings.TrimSpace(agent); a != "" && !strings.EqualFold(event.AgentName, a) {
-		return false
-	}
-	if s := strings.TrimSpace(service); s != "" && !strings.EqualFold(event.Service, s) {
-		return false
-	}
-	return true
 }
 
 func parseAuditTime(raw string) (time.Time, error) {

--- a/cmd/kimbap/audit_filters.go
+++ b/cmd/kimbap/audit_filters.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dunialabs/kimbap/internal/audit"
+)
+
+type auditEventFilter struct {
+	Agent   string
+	Service string
+	Action  string
+	Status  string
+}
+
+type auditQueryWindow struct {
+	Kind  string
+	Value string
+	From  *time.Time
+	To    *time.Time
+}
+
+type auditWindowOutput struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value,omitempty"`
+	From  string `json:"from,omitempty"`
+	To    string `json:"to,omitempty"`
+}
+
+func newAuditEventFilter(agent string, service string, action string, status string) auditEventFilter {
+	return auditEventFilter{
+		Agent:   strings.TrimSpace(agent),
+		Service: strings.TrimSpace(service),
+		Action:  strings.TrimSpace(action),
+		Status:  strings.TrimSpace(status),
+	}
+}
+
+func (f auditEventFilter) matches(event audit.AuditEvent) bool {
+	if f.Agent != "" && !strings.EqualFold(strings.TrimSpace(event.AgentName), f.Agent) {
+		return false
+	}
+	if f.Service != "" && !strings.EqualFold(strings.TrimSpace(event.Service), f.Service) {
+		return false
+	}
+	if f.Action != "" && !strings.EqualFold(strings.TrimSpace(event.Action), f.Action) {
+		return false
+	}
+	if f.Status != "" && !strings.EqualFold(string(event.Status), f.Status) {
+		return false
+	}
+	return true
+}
+
+func (f auditEventFilter) output() auditSummaryFilters {
+	return auditSummaryFilters{
+		Agent:   f.Agent,
+		Service: f.Service,
+		Action:  f.Action,
+		Status:  f.Status,
+	}
+}
+
+func parseAuditSinceDuration(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return 0, fmt.Errorf("--since is required")
+	}
+	if strings.HasSuffix(raw, "d") {
+		daysRaw := strings.TrimSuffix(raw, "d")
+		days, err := strconv.Atoi(daysRaw)
+		if err != nil || days <= 0 {
+			return 0, fmt.Errorf("unsupported --since value %q", raw)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	dur, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse --since: %w", err)
+	}
+	if dur <= 0 {
+		return 0, fmt.Errorf("--since must be greater than 0")
+	}
+	return dur, nil
+}
+
+func resolveAuditQueryWindow(since string, from string, to string, defaultSince time.Duration, now time.Time) (auditQueryWindow, error) {
+	since = strings.TrimSpace(since)
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	now = now.UTC()
+
+	if since != "" && (from != "" || to != "") {
+		return auditQueryWindow{}, fmt.Errorf("--since cannot be combined with --from or --to")
+	}
+
+	if since == "" && from == "" && to == "" {
+		since = defaultSince.String()
+	}
+
+	if since != "" {
+		dur, err := parseAuditSinceDuration(since)
+		if err != nil {
+			return auditQueryWindow{}, err
+		}
+		fromTime := now.Add(-dur)
+		toTime := now
+		return auditQueryWindow{
+			Kind:  "since",
+			Value: since,
+			From:  &fromTime,
+			To:    &toTime,
+		}, nil
+	}
+
+	window := auditQueryWindow{Kind: "range"}
+	if from != "" {
+		fromTime, err := parseAuditTime(from)
+		if err != nil {
+			return auditQueryWindow{}, fmt.Errorf("parse --from: %w", err)
+		}
+		window.From = &fromTime
+	}
+	if to != "" {
+		toTime, err := parseAuditTimeTo(to)
+		if err != nil {
+			return auditQueryWindow{}, fmt.Errorf("parse --to: %w", err)
+		}
+		window.To = &toTime
+	}
+	if window.From != nil && window.To == nil {
+		toTime := now
+		window.To = &toTime
+	}
+	if window.From != nil && window.To != nil && window.To.Before(*window.From) {
+		return auditQueryWindow{}, fmt.Errorf("--to must be after or equal to --from")
+	}
+	return window, nil
+}
+
+func (w auditQueryWindow) contains(ts time.Time) bool {
+	if w.From != nil && ts.Before(*w.From) {
+		return false
+	}
+	if w.To != nil && ts.After(*w.To) {
+		return false
+	}
+	return true
+}
+
+func (w auditQueryWindow) output() auditWindowOutput {
+	out := auditWindowOutput{
+		Kind:  w.Kind,
+		Value: w.Value,
+	}
+	if w.From != nil {
+		out.From = w.From.Format(time.RFC3339)
+	}
+	if w.To != nil {
+		out.To = w.To.Format(time.RFC3339)
+	}
+	return out
+}

--- a/cmd/kimbap/audit_summary.go
+++ b/cmd/kimbap/audit_summary.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/dunialabs/kimbap/internal/audit"
+)
+
+const auditSummaryTopPreviewLimit = 3
+
+type auditSummaryResult struct {
+	Window        auditWindowOutput   `json:"window"`
+	Filters       auditSummaryFilters `json:"filters"`
+	MatchedEvents int                 `json:"matched_events"`
+	StatusCounts  auditStatusCounts   `json:"status_counts"`
+	StatusRatios  auditStatusRatios   `json:"status_ratios"`
+	LatencyMS     auditLatencySummary `json:"latency_ms"`
+	ModeCounts    []auditCountItem    `json:"mode_counts"`
+	TopServices   []auditCountItem    `json:"top_services"`
+	TopActions    []auditCountItem    `json:"top_actions"`
+	TopAgents     []auditCountItem    `json:"top_agents"`
+	TopErrorCodes []auditCountItem    `json:"top_error_codes"`
+}
+
+type auditSummaryFilters struct {
+	Agent   string `json:"agent"`
+	Service string `json:"service"`
+	Action  string `json:"action"`
+	Status  string `json:"status"`
+}
+
+type auditStatusCounts struct {
+	Success          int `json:"success"`
+	Error            int `json:"error"`
+	Denied           int `json:"denied"`
+	ApprovalRequired int `json:"approval_required"`
+	ValidationFailed int `json:"validation_failed"`
+	Timeout          int `json:"timeout"`
+	Cancelled        int `json:"cancelled"`
+}
+
+type auditStatusRatios struct {
+	Success          float64 `json:"success"`
+	Error            float64 `json:"error"`
+	Denied           float64 `json:"denied"`
+	ApprovalRequired float64 `json:"approval_required"`
+	ValidationFailed float64 `json:"validation_failed"`
+	Timeout          float64 `json:"timeout"`
+	Cancelled        float64 `json:"cancelled"`
+}
+
+type auditLatencySummary struct {
+	Avg int64 `json:"avg"`
+	P50 int64 `json:"p50"`
+	P95 int64 `json:"p95"`
+	Max int64 `json:"max"`
+}
+
+type auditCountItem struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+type auditSummaryAggregate struct {
+	matched     int
+	statuses    auditStatusCounts
+	sumDuration int64
+	maxDuration int64
+	durations   []int64
+	modeCounts  map[string]int
+	serviceHits map[string]int
+	actionHits  map[string]int
+	agentHits   map[string]int
+	errorHits   map[string]int
+}
+
+func summarizeAuditEvents(path string, window auditQueryWindow, filter auditEventFilter) (auditSummaryResult, error) {
+	agg := auditSummaryAggregate{
+		modeCounts:  map[string]int{},
+		serviceHits: map[string]int{},
+		actionHits:  map[string]int{},
+		agentHits:   map[string]int{},
+		errorHits:   map[string]int{},
+	}
+	if err := forEachAuditEvent(path, func(event audit.AuditEvent) error {
+		if !window.contains(event.Timestamp) || !filter.matches(event) {
+			return nil
+		}
+		agg.consume(event)
+		return nil
+	}); err != nil {
+		return auditSummaryResult{}, err
+	}
+
+	return auditSummaryResult{
+		Window:        window.output(),
+		Filters:       filter.output(),
+		MatchedEvents: agg.matched,
+		StatusCounts:  agg.statuses,
+		StatusRatios:  agg.statusRatios(),
+		LatencyMS:     agg.latencySummary(),
+		ModeCounts:    topAuditCounts(agg.modeCounts, 0),
+		TopServices:   topAuditCounts(agg.serviceHits, auditSummaryTopPreviewLimit),
+		TopActions:    topAuditCounts(agg.actionHits, auditSummaryTopPreviewLimit),
+		TopAgents:     topAuditCounts(agg.agentHits, auditSummaryTopPreviewLimit),
+		TopErrorCodes: topAuditCounts(agg.errorHits, auditSummaryTopPreviewLimit),
+	}, nil
+}
+
+func (a *auditSummaryAggregate) consume(event audit.AuditEvent) {
+	a.matched++
+	switch event.Status {
+	case audit.AuditStatusSuccess:
+		a.statuses.Success++
+	case audit.AuditStatusError:
+		a.statuses.Error++
+	case audit.AuditStatusDenied:
+		a.statuses.Denied++
+	case audit.AuditStatusApprovalRequired:
+		a.statuses.ApprovalRequired++
+	case audit.AuditStatusValidationFailed:
+		a.statuses.ValidationFailed++
+	case audit.AuditStatusTimeout:
+		a.statuses.Timeout++
+	case audit.AuditStatusCancelled:
+		a.statuses.Cancelled++
+	}
+
+	a.sumDuration += event.DurationMS
+	if event.DurationMS > a.maxDuration {
+		a.maxDuration = event.DurationMS
+	}
+	a.durations = append(a.durations, event.DurationMS)
+
+	if key := strings.TrimSpace(event.Mode); key != "" {
+		a.modeCounts[key]++
+	}
+	if key := strings.TrimSpace(event.Service); key != "" {
+		a.serviceHits[key]++
+	}
+	if key := auditActionKey(event); key != "" {
+		a.actionHits[key]++
+	}
+	if key := strings.TrimSpace(event.AgentName); key != "" {
+		a.agentHits[key]++
+	}
+	if event.Error != nil {
+		if key := strings.TrimSpace(event.Error.Code); key != "" {
+			a.errorHits[key]++
+		}
+	}
+}
+
+func (a auditSummaryAggregate) statusRatios() auditStatusRatios {
+	total := float64(a.matched)
+	if total == 0 {
+		return auditStatusRatios{}
+	}
+	return auditStatusRatios{
+		Success:          float64(a.statuses.Success) / total,
+		Error:            float64(a.statuses.Error) / total,
+		Denied:           float64(a.statuses.Denied) / total,
+		ApprovalRequired: float64(a.statuses.ApprovalRequired) / total,
+		ValidationFailed: float64(a.statuses.ValidationFailed) / total,
+		Timeout:          float64(a.statuses.Timeout) / total,
+		Cancelled:        float64(a.statuses.Cancelled) / total,
+	}
+}
+
+func (a auditSummaryAggregate) latencySummary() auditLatencySummary {
+	if a.matched == 0 {
+		return auditLatencySummary{}
+	}
+	sorted := append([]int64(nil), a.durations...)
+	slices.Sort(sorted)
+	return auditLatencySummary{
+		Avg: a.sumDuration / int64(a.matched),
+		P50: percentileNearestRank(sorted, 50),
+		P95: percentileNearestRank(sorted, 95),
+		Max: a.maxDuration,
+	}
+}
+
+func auditActionKey(event audit.AuditEvent) string {
+	service := strings.TrimSpace(event.Service)
+	action := strings.TrimSpace(event.Action)
+	switch {
+	case service != "" && action != "":
+		return service + "." + action
+	case action != "":
+		return action
+	default:
+		return ""
+	}
+}
+
+func topAuditCounts(counts map[string]int, limit int) []auditCountItem {
+	items := make([]auditCountItem, 0, len(counts))
+	for key, count := range counts {
+		if strings.TrimSpace(key) == "" || count <= 0 {
+			continue
+		}
+		items = append(items, auditCountItem{Key: key, Count: count})
+	}
+	slices.SortFunc(items, func(left auditCountItem, right auditCountItem) int {
+		if left.Count != right.Count {
+			if left.Count > right.Count {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(left.Key, right.Key)
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items
+}
+
+func percentileNearestRank(sorted []int64, percentile int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(math.Ceil(float64(percentile) / 100 * float64(len(sorted))))
+	if rank <= 0 {
+		rank = 1
+	}
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+	return sorted[rank-1]
+}
+
+func renderAuditSummaryText(summary auditSummaryResult) string {
+	lines := []string{
+		fmt.Sprintf("%-14s%s", "Window:", formatAuditWindowLineFromOutput(summary.Window)),
+		fmt.Sprintf("%-14s%s", "Range:", formatAuditRangeLineFromOutput(summary.Window)),
+		fmt.Sprintf("%-14s%d events", "Matched:", summary.MatchedEvents),
+	}
+
+	if summary.MatchedEvents == 0 {
+		lines = append(lines, "", "No audit events matched.")
+		return strings.Join(lines, "\n")
+	}
+
+	lines = append(lines, "", "Status:")
+	for _, row := range auditStatusTextRows(summary.StatusCounts, summary.StatusRatios) {
+		lines = append(lines, row)
+	}
+
+	lines = append(lines,
+		"",
+		"Latency:",
+		fmt.Sprintf("  avg %dms   p50 %dms   p95 %dms   max %dms",
+			summary.LatencyMS.Avg,
+			summary.LatencyMS.P50,
+			summary.LatencyMS.P95,
+			summary.LatencyMS.Max,
+		),
+	)
+
+	appendAuditCountSection(&lines, "Modes:", summary.ModeCounts)
+	appendAuditCountSection(&lines, "Top Services:", summary.TopServices)
+	appendAuditCountSection(&lines, "Top Actions:", summary.TopActions)
+	appendAuditCountSection(&lines, "Top Agents:", summary.TopAgents)
+	appendAuditCountSection(&lines, "Top Error Codes:", summary.TopErrorCodes)
+
+	return strings.Join(lines, "\n")
+}
+
+func auditStatusTextRows(counts auditStatusCounts, ratios auditStatusRatios) []string {
+	rows := make([]string, 0, 7)
+	add := func(label string, count int, ratio float64) {
+		if count == 0 {
+			return
+		}
+		rows = append(rows, fmt.Sprintf("  %-20s %5d  %5.1f%%", label, count, ratio*100))
+	}
+	add("success", counts.Success, ratios.Success)
+	add("error", counts.Error, ratios.Error)
+	add("denied", counts.Denied, ratios.Denied)
+	add("approval_required", counts.ApprovalRequired, ratios.ApprovalRequired)
+	add("validation_failed", counts.ValidationFailed, ratios.ValidationFailed)
+	add("timeout", counts.Timeout, ratios.Timeout)
+	add("cancelled", counts.Cancelled, ratios.Cancelled)
+	if len(rows) == 0 {
+		rows = append(rows, "  (none)")
+	}
+	return rows
+}
+
+func appendAuditCountSection(lines *[]string, title string, items []auditCountItem) {
+	if len(items) == 0 {
+		return
+	}
+	*lines = append(*lines, "", title)
+	for _, item := range items {
+		*lines = append(*lines, fmt.Sprintf("  %-20s %5d", item.Key, item.Count))
+	}
+}
+
+func formatAuditWindowLineFromOutput(window auditWindowOutput) string {
+	if window.Kind == "since" && strings.TrimSpace(window.Value) != "" {
+		return "last " + strings.TrimSpace(window.Value)
+	}
+	return "custom"
+}
+
+func formatAuditRangeLineFromOutput(window auditWindowOutput) string {
+	return formatAuditTextTime(window.From, "beginning") + " -> " + formatAuditTextTime(window.To, "now")
+}
+
+func formatAuditTextTime(raw string, fallback string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fallback
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	return ts.UTC().Format("2006-01-02 15:04:05Z07:00")
+}

--- a/cmd/kimbap/audit_test.go
+++ b/cmd/kimbap/audit_test.go
@@ -62,3 +62,179 @@ func TestForEachAuditEventReturnsNilForMissingFile(t *testing.T) {
 		t.Fatalf("expected nil for missing file, got %v", err)
 	}
 }
+
+func TestParseAuditSinceDurationSupportsDays(t *testing.T) {
+	dur, err := parseAuditSinceDuration("7d")
+	if err != nil {
+		t.Fatalf("parseAuditSinceDuration returned error: %v", err)
+	}
+	if want := 7 * 24 * time.Hour; dur != want {
+		t.Fatalf("expected %s, got %s", want, dur)
+	}
+}
+
+func TestResolveAuditQueryWindowRejectsMixedSinceAndRange(t *testing.T) {
+	_, err := resolveAuditQueryWindow("24h", "2026-04-19", "", 24*time.Hour, time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected mixed --since/--from to fail")
+	}
+}
+
+func TestSummarizeAuditEvents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	events := []audit.AuditEvent{
+		newAuditFixtureEvent("evt1", "2026-04-19T10:00:00Z", "codex", "github", "list-issues", "call", audit.AuditStatusSuccess, 50, ""),
+		newAuditFixtureEvent("evt2", "2026-04-19T10:05:00Z", "codex", "github", "list-repos", "call", audit.AuditStatusError, 120, "ERR_DOWNSTREAM"),
+		newAuditFixtureEvent("evt3", "2026-04-19T10:10:00Z", "claude", "slack", "post-message", "serve", audit.AuditStatusApprovalRequired, 300, ""),
+		newAuditFixtureEvent("evt4", "2026-04-19T10:15:00Z", "codex", "github", "list-issues", "call", audit.AuditStatusValidationFailed, 20, "ERR_VALIDATION"),
+		newAuditFixtureEvent("evt5", "2026-04-19T10:20:00Z", "codex", "notion", "query", "call", audit.AuditStatusTimeout, 500, "ERR_TIMEOUT"),
+		newAuditFixtureEvent("evt6", "2026-04-19T10:25:00Z", "claude", "github", "list-issues", "call", audit.AuditStatusDenied, 10, ""),
+		newAuditFixtureEvent("evt7", "2026-04-19T10:30:00Z", "codex", "stripe", "charge", "call", audit.AuditStatusCancelled, 40, "ERR_CANCELLED"),
+	}
+	writeAuditFixture(t, path, events)
+
+	fromTime, err := parseAuditTime("2026-04-19")
+	if err != nil {
+		t.Fatalf("parseAuditTime returned error: %v", err)
+	}
+	toTime, err := parseAuditTimeTo("2026-04-20")
+	if err != nil {
+		t.Fatalf("parseAuditTimeTo returned error: %v", err)
+	}
+	summary, err := summarizeAuditEvents(path, auditQueryWindow{
+		Kind: "range",
+		From: &fromTime,
+		To:   &toTime,
+	}, newAuditEventFilter("", "", "", ""))
+	if err != nil {
+		t.Fatalf("summarizeAuditEvents returned error: %v", err)
+	}
+
+	if summary.MatchedEvents != 7 {
+		t.Fatalf("expected 7 matched events, got %d", summary.MatchedEvents)
+	}
+	if summary.StatusCounts.Success != 1 || summary.StatusCounts.Error != 1 || summary.StatusCounts.Denied != 1 ||
+		summary.StatusCounts.ApprovalRequired != 1 || summary.StatusCounts.ValidationFailed != 1 ||
+		summary.StatusCounts.Timeout != 1 || summary.StatusCounts.Cancelled != 1 {
+		t.Fatalf("unexpected status counts: %+v", summary.StatusCounts)
+	}
+	if summary.LatencyMS.Avg != 148 || summary.LatencyMS.P50 != 50 || summary.LatencyMS.P95 != 500 || summary.LatencyMS.Max != 500 {
+		t.Fatalf("unexpected latency summary: %+v", summary.LatencyMS)
+	}
+	if len(summary.TopServices) == 0 || summary.TopServices[0].Key != "github" || summary.TopServices[0].Count != 4 {
+		t.Fatalf("unexpected top services: %+v", summary.TopServices)
+	}
+	if len(summary.TopAgents) == 0 || summary.TopAgents[0].Key != "codex" || summary.TopAgents[0].Count != 5 {
+		t.Fatalf("unexpected top agents: %+v", summary.TopAgents)
+	}
+	if len(summary.ModeCounts) != 2 || summary.ModeCounts[0].Key != "call" || summary.ModeCounts[0].Count != 6 {
+		t.Fatalf("unexpected mode counts: %+v", summary.ModeCounts)
+	}
+	if len(summary.TopErrorCodes) != 3 {
+		t.Fatalf("expected top error preview limit of 3, got %+v", summary.TopErrorCodes)
+	}
+}
+
+func TestRenderAuditSummaryText(t *testing.T) {
+	summary := auditSummaryResult{
+		Window:        auditWindowOutput{Kind: "since", Value: "24h", From: "2026-04-19T00:00:00Z", To: "2026-04-20T00:00:00Z"},
+		MatchedEvents: 2,
+		StatusCounts: auditStatusCounts{
+			Success: 1,
+			Error:   1,
+		},
+		StatusRatios: auditStatusRatios{
+			Success: 0.5,
+			Error:   0.5,
+		},
+		LatencyMS: auditLatencySummary{Avg: 85, P50: 50, P95: 120, Max: 120},
+		TopServices: []auditCountItem{
+			{Key: "github", Count: 2},
+		},
+	}
+
+	text := renderAuditSummaryText(summary)
+	if !strings.Contains(text, "Window:") || !strings.Contains(text, "last 24h") {
+		t.Fatalf("expected window header, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Status:") || !strings.Contains(text, "success") || !strings.Contains(text, "error") {
+		t.Fatalf("expected status section, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Latency:") || !strings.Contains(text, "p95 120ms") {
+		t.Fatalf("expected latency section, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Top Services:") || !strings.Contains(text, "github") {
+		t.Fatalf("expected top services section, got:\n%s", text)
+	}
+}
+
+func TestAuditSummaryCommandOutputsJSON(t *testing.T) {
+	resetOptsForTest(t)
+	opts.format = "json"
+
+	dataDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeMinimalConfig(t, configPath, dataDir, t.TempDir())
+	writeAuditFixture(t, filepath.Join(dataDir, "audit.jsonl"), []audit.AuditEvent{
+		newAuditFixtureEvent("evt1", "2026-04-19T10:00:00Z", "codex", "github", "list-issues", "call", audit.AuditStatusSuccess, 50, ""),
+		newAuditFixtureEvent("evt2", "2026-04-19T10:05:00Z", "codex", "github", "list-repos", "call", audit.AuditStatusError, 120, "ERR_DOWNSTREAM"),
+	})
+
+	opts.configPath = configPath
+	output, err := captureStdout(t, func() error {
+		cmd := newAuditSummaryCommand()
+		cmd.SetArgs([]string{"--from", "2026-04-19", "--to", "2026-04-20"})
+		return cmd.Execute()
+	})
+	if err != nil {
+		t.Fatalf("summary command failed: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf("summary output is not valid JSON: %v\noutput=%s", err, output)
+	}
+	if got := int(payload["matched_events"].(float64)); got != 2 {
+		t.Fatalf("expected matched_events=2, got %d", got)
+	}
+	filters, _ := payload["filters"].(map[string]any)
+	if filters == nil {
+		t.Fatalf("expected filters object, got %v", payload["filters"])
+	}
+}
+
+func newAuditFixtureEvent(id string, timestamp string, agent string, service string, action string, mode string, status audit.AuditStatus, durationMS int64, errorCode string) audit.AuditEvent {
+	eventTime, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		panic(err)
+	}
+	event := audit.AuditEvent{
+		ID:         id,
+		Timestamp:  eventTime.UTC(),
+		AgentName:  agent,
+		Service:    service,
+		Action:     action,
+		Mode:       mode,
+		Status:     status,
+		DurationMS: durationMS,
+	}
+	if errorCode != "" {
+		event.Error = &audit.AuditError{Code: errorCode}
+	}
+	return event
+}
+
+func writeAuditFixture(t *testing.T, path string, events []audit.AuditEvent) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create audit fixture: %v", err)
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	for _, event := range events {
+		if err := enc.Encode(event); err != nil {
+			t.Fatalf("encode audit fixture: %v", err)
+		}
+	}
+}

--- a/cmd/kimbap/readonly_commands_test.go
+++ b/cmd/kimbap/readonly_commands_test.go
@@ -152,6 +152,72 @@ func TestAuthStatusDoesNotMaterializeDataDir(t *testing.T) {
 	}
 }
 
+func TestAuditTailDoesNotMaterializeDataDir(t *testing.T) {
+	servicesDir := t.TempDir()
+	missingDataDir := filepath.Join(t.TempDir(), "missing-data-dir")
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	writeMinimalConfig(t, configPath, missingDataDir, servicesDir)
+
+	prev := opts
+	opts = cliOptions{configPath: configPath}
+	t.Cleanup(func() { opts = prev })
+
+	cmd := newAuditTailCommand()
+	cmd.SetArgs([]string{"--service", "github", "--action", "list-issues", "--status", "success"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("audit tail failed: %v", err)
+	}
+
+	if _, err := os.Stat(missingDataDir); !os.IsNotExist(err) {
+		t.Fatalf("audit tail must not create data_dir, stat err=%v", err)
+	}
+}
+
+func TestAuditExportDoesNotMaterializeDataDir(t *testing.T) {
+	servicesDir := t.TempDir()
+	missingDataDir := filepath.Join(t.TempDir(), "missing-data-dir")
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	writeMinimalConfig(t, configPath, missingDataDir, servicesDir)
+
+	prev := opts
+	opts = cliOptions{configPath: configPath}
+	t.Cleanup(func() { opts = prev })
+
+	cmd := newAuditExportCommand()
+	cmd.SetArgs([]string{"--from", "2026-04-19", "--to", "2026-04-20"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("audit export failed: %v", err)
+	}
+
+	if _, err := os.Stat(missingDataDir); !os.IsNotExist(err) {
+		t.Fatalf("audit export must not create data_dir, stat err=%v", err)
+	}
+}
+
+func TestAuditSummaryDoesNotMaterializeDataDir(t *testing.T) {
+	servicesDir := t.TempDir()
+	missingDataDir := filepath.Join(t.TempDir(), "missing-data-dir")
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	writeMinimalConfig(t, configPath, missingDataDir, servicesDir)
+
+	prev := opts
+	opts = cliOptions{configPath: configPath}
+	t.Cleanup(func() { opts = prev })
+
+	cmd := newAuditSummaryCommand()
+	cmd.SetArgs([]string{"--since", "24h"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("audit summary failed: %v", err)
+	}
+
+	if _, err := os.Stat(missingDataDir); !os.IsNotExist(err) {
+		t.Fatalf("audit summary must not create data_dir, stat err=%v", err)
+	}
+}
+
 func TestAuthListDoesNotMutateExistingConnectorDB(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "kimbap.db")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -619,10 +619,17 @@ kimbap approve accept req_01HX...
 
 Show a recent snapshot of audit log entries (non-streaming). Error messages in audit records are capped at 256 characters.
 
+**Syntax:**
+
+```bash
+kimbap audit tail [--agent <name>] [--service <name>] [--action <name>] [--status <status>] [--limit 20]
+```
+
 **Example:**
 
 ```bash
 kimbap audit tail
+kimbap audit tail --service github --action list-issues --status success
 ```
 
 ---
@@ -644,6 +651,30 @@ Accepted date formats for `--from` / `--to`: `RFC3339` or `YYYY-MM-DD`.
 ```bash
 kimbap audit export --from 2026-03-01 --to 2026-03-31
 kimbap audit export --from 2026-03-01 --to 2026-03-31 --format csv > audit-202603.csv
+```
+
+---
+
+### kimbap audit summary
+
+Show an aggregated summary for a recent audit window. This is the default spot-check command when you want a quick view of usage, status distribution, latency, and the most active services or actions.
+
+**Syntax:**
+
+```bash
+kimbap audit summary [--since <duration> | --from <time> --to <time>] [--agent <name>] [--service <name>] [--action <name>] [--status <status>]
+```
+
+Accepted `--since` examples: Go durations such as `24h`, plus integer day shorthands such as `7d`.
+
+Accepted date formats for `--from` / `--to`: `RFC3339` or `YYYY-MM-DD`.
+
+**Example:**
+
+```bash
+kimbap audit summary --since 24h
+kimbap audit summary --since 7d --service github
+kimbap audit summary --from 2026-04-01 --to 2026-04-20 --status error
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add `kimbap audit summary` for one-command audit spot checks
- make audit read commands use read-only config loading and extend `audit tail` with `--action` / `--status`
- add audit summary tests, read-only command coverage, and CLI reference updates

## Testing
- go test ./cmd/kimbap
- go test ./...